### PR TITLE
fix: search suggestion error

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -123,7 +123,8 @@ export const SearchBar = ({onSearch, onClear}: SearchBarProps) => {
     const setSuggestion = (suggestion: string) => {
         console.log("suggestion", suggestion)
         setPrompt(suggestion);
-        handleSearch();
+        onSearch(suggestion);
+        setQuery(suggestion);
         pushQuery(suggestion);
     }
 


### PR DESCRIPTION
<h3 style="font-size: 24px">Issues:</h3>
 when clicked on suggestions it won't show the search results.

<h3 style="font-size: 24px">Cause:</h3>
I think Its because the `handleSearch()` is immediately called after the `setPrompt()`, the `prompt` state is not immediately updated because of the async nature of `useState` hook. and the `handleSearch()` rely on `prompt` state, causing the query string to be empty string.

<h3 style="font-size: 24px">Solution:</h3>
For the fix I called the `pushQuery(suggestion)` directly from `setSuggestion()` instead of relying on `handleSearch` function which rely on the `prompt` state. also set the additional values that `handleSearch` sets like `setQuery` and `onSearch`.

