### PR TITLE
fix: empty directory error

### DIFF
--- a/src/services/unbody.service.ts
+++ b/src/services/unbody.service.ts
@@ -225,7 +225,7 @@ const createDirectories = async (
             return (post.pathString as string).startsWith(`/${directory}/`);
         });
 
-        if (postsInDirectory.length===0) return [];
+        if (postsInDirectory.length===0) return null;
 
         let prompt = "You are going to help me define and extract some information from the given document.\n";
         prompt += `This is a content that represent one single directory in a website, where all directories are related to eachother, the context and content of each can be different.`;


### PR DESCRIPTION
if (postsInDirectory.length===0) return [];


this line you added creates another bug,

so we are getting the extra directory "My Drive" this will return 
My Drive = [] to be an empty array, which as 0 posts.

This will create error in DirectoryCard


<h2 style="font-size:12px;">If this is the case I have created the PR with the fix 🚀</h2>